### PR TITLE
Point to ns8-stable install.sh URL

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -24,7 +24,7 @@ First, make sure the system is up to date and ``curl`` is installed:
 
 Start the installation procedure as ``root``: ::
 
-   curl https://raw.githubusercontent.com/NethServer/ns8-core/main/core/install.sh | bash
+   curl https://raw.githubusercontent.com/NethServer/ns8-core/ns8-stable/core/install.sh | bash
 
 When the installation script ends, access the Web user interface at ::
 


### PR DESCRIPTION
Download install.sh from the latest-stable-tagged release.

Requires https://github.com/NethServer/ns8-core/pull/421