### PR TITLE
Add Samba restore information

### DIFF
--- a/backup.rst
+++ b/backup.rst
@@ -39,6 +39,8 @@ Whenever you want to manually execute the backup, click the ``Run backup now`` i
 
 To add more instances to an existing backup, click the ``Edit`` item from the three-dots menu of the scheduled backup.
 
+.. _application_restore-section:
+
 Application restore
 ===================
 

--- a/file_server.rst
+++ b/file_server.rst
@@ -57,6 +57,42 @@ the shared folder root directory. It is possible to edit ACLs with a SMB
 client, like the Windows Explorer application installed with Windows Pro
 flavours, or the ``smbcacls`` command provided by the Samba project.
 
+
+Restore file server from backup
+===============================
+
+.. warning::
+
+    To avoid reconfiguring network clients the system should provide the
+    same IP address used in the file server backup.
+
+First of all, apply the procedure described in
+:ref:`application_restore-section` by selecting the backup of the **Samba
+module**.
+
+If the restored controller is the first of the domain there are
+two alternatives:
+
+1. If the system IP address is the same used in the backup set, DC
+   services are started automatically and no further actions are required.
+
+2. If the previous condition does not apply, DC services are started using
+   the system VPN IP address as fallback. A similar command is required to
+   select another IP address in a second time: ::
+
+     api-cli run module/samba0/set-ipaddress --data '{"ipaddress": "10.15.21.100"}'
+
+   Replace `samba0` with the correct module identifier. Replace the
+   `ipaddress` value with the correct IP address.
+
+Otherwise, if one or more domain controllers already exist:
+
+- go to ``Domain and users`` page and open the :guilabel:`Unconfigured
+  provider` link;
+
+- fill the form to join a new DC to the domain.
+
+
 .. rubric:: Footnotes
 
 .. [#anon] *Guest access in SMB2 and SMB3 disabled by default in Windows*


### PR DESCRIPTION
Restoring a DC File server has some assumptions and may need additional configuration steps. This is the documentation.

See also https://github.com/NethServer/ns8-samba/pull/21