### PR TITLE
verify FQDN before to initiate the cluster

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -22,6 +22,9 @@ First, make sure the system is up to date and ``curl`` is installed:
 * for CentOS/AlmaLinux/RockyLinux: ``dnf update -y && dnf install -y curl``
 * for Debian: ``apt-get update && apt-get upgrade -y && apt-get install -y curl``
 
+Then verify that the fully qualified domain name of your server is correctly set. To reach your server the FQDN must have DNS entries from your DNS registar. If the FQDN has to be changed you must refer to the manual of your linux distribution.
+to verify :``hostname -f``
+
 Start the installation procedure as ``root``: ::
 
    curl https://raw.githubusercontent.com/NethServer/ns8-core/ns8-stable/core/install.sh | bash

--- a/install.rst
+++ b/install.rst
@@ -22,8 +22,8 @@ First, make sure the system is up to date and ``curl`` is installed:
 * for CentOS/AlmaLinux/RockyLinux: ``dnf update -y && dnf install -y curl``
 * for Debian: ``apt-get update && apt-get upgrade -y && apt-get install -y curl``
 
-Then verify that the fully qualified domain name of your server is correctly set. To reach your server the FQDN must have DNS entries from your DNS registrar. If the FQDN has to be changed you must refer to the manual of your linux distribution.
-to verify :``hostname -f``
+Then verify that the fully qualified domain name of your server is correctly set. To reach your server the FQDN must have DNS entries from your DNS registrar. If the FQDN has to be changed you must refer to the manual of your Linux distribution.
+To check current configured hostname use: ``hostname -f``
 
 Start the installation procedure as ``root``: ::
 

--- a/install.rst
+++ b/install.rst
@@ -22,7 +22,7 @@ First, make sure the system is up to date and ``curl`` is installed:
 * for CentOS/AlmaLinux/RockyLinux: ``dnf update -y && dnf install -y curl``
 * for Debian: ``apt-get update && apt-get upgrade -y && apt-get install -y curl``
 
-Then verify that the fully qualified domain name of your server is correctly set. To reach your server the FQDN must have DNS entries from your DNS registar. If the FQDN has to be changed you must refer to the manual of your linux distribution.
+Then verify that the fully qualified domain name of your server is correctly set. To reach your server the FQDN must have DNS entries from your DNS registrar. If the FQDN has to be changed you must refer to the manual of your linux distribution.
 to verify :``hostname -f``
 
 Start the installation procedure as ``root``: ::


### PR DESCRIPTION
Before to install the node and initiate the cluster we could warn the sysadmin to verify if it server gets the good FQDN