### PR TITLE
Use `nmtui` to fix network configuration

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -64,6 +64,7 @@ NethServer 8 administrator manual
    :maxdepth: 2
    :caption: Best practices
 
+   os_network
    os_updates
    disk_usage
    migration

--- a/install.rst
+++ b/install.rst
@@ -62,6 +62,10 @@ access the Web user interface at ::
 
     https://<server_ip_or_fqdn>/cluster-admin/
 
+.. hint::
+
+   If the node is unreachable see :ref:`os-network-section`
+
 Use the default credentials to login:
 
 * Username: ``admin``

--- a/os_network.rst
+++ b/os_network.rst
@@ -1,0 +1,47 @@
+.. _os-network-section:
+
+==================
+Node network setup
+==================
+
+A workable network configuration could be already provided by an automatic
+procedure, like ``cloud-init``.  If you are running a cloud VPS, do not
+change the node network settings, and **read the cloud provider
+documentation** before changing the node host name.
+
+Also the **OS installation procedure** can help to set up a working network
+setup for your node. In this case refer to the OS documentation.
+
+In any other case, if the node cannot be reached from the network, enter
+the system console and try to fix the network configuration with one of
+the following methods.
+
+The basic parameters to fix the node network configuration are:
+
+1. The public network interface name, for example ``eth0``
+2. A static IP address and network mask to assign, for example ``192.168.12.3/24``
+3. The network default gateway IP address. It is an IP address in the same
+   network of your node, for instance ``192.168.12.1``
+4. The DNS server address. It can be a public DNS service, like Google
+   ``8.8.8.8`` or ``8.8.4.4``, Cloudflare ``1.1.1.1``, or a private DNS
+   server. In small environments it could be the gateway host itself.
+
+``nmtui``
+=========
+
+The ``nmtui`` (Text User Interface for controlling NetworkManager) is
+available on EL distributions, like CentOS Stream, Alma and Rocky Linux.
+
+Launch the text interface to edit network connections with: ::
+
+    nmtui edit
+
+This is a summary of keyboard functions:
+
+* Arrows and tab keys move between interface elements (like buttons and
+  form fields)
+* ``Enter``, button click
+* ``Esc``, cancel, back to previous screen
+* ``Space``, modify checkbox, selection
+* ``Ctrl+C``, abort
+


### PR DESCRIPTION
The ``nmtui`` command is available on EL distros. It can be used to fix a bad network configuration from the console with a text-based interface.