### PR TITLE
Migrate POP3 Connector to Imapsync

### DIFF
--- a/migration.rst
+++ b/migration.rst
@@ -75,11 +75,11 @@ access to the account provider.
 
 .. _getmail_migration-section:
 
-Getmail
-=======
+POP3 connector
+==============
 
-The migration involves transferring the Connector module to the Imapsync module, together with NethServer 7's Email application.
-This migration process transfers all your connector settings to the imapsync module and initiates synchronization if you were previously using the IMAP protocol.
+The migration involves transferring POP3 Connector settings to NS8 Imapsync module, together with Email application.
+Configuration of accounts using the IMAP protocol are translated to working Imapsync tasks.
 If you were using POP3, it's necessary to review the settings and commence synchronization manually.
 
 .. rubric:: Configurations excluded from migration

--- a/migration.rst
+++ b/migration.rst
@@ -73,6 +73,15 @@ for NS7. Bear in mind that NS7 must be able to access the :ref:`IP address <acti
 This configuration could be useful if you have modules still running on NS7 that require
 access to the account provider.
 
+.. _getmail_migration-section:
+
+Getmail
+=======
+
+The migration involves transferring the Connector module to the Imapsync module, together with NethServer 7's Email application.
+This migration process transfers all your connector settings to the imapsync module and initiates synchronization if you were previously using the IMAP protocol.
+If you were using POP3, it's necessary to review the settings and commence synchronization manually.
+
 .. rubric:: Configurations excluded from migration
 
 The following configurations will not be migrated:

--- a/migration.rst
+++ b/migration.rst
@@ -79,8 +79,8 @@ POP3 connector
 ==============
 
 The migration involves transferring POP3 Connector settings to NS8 Imapsync module, together with Email application.
-Configuration of accounts using the IMAP protocol are translated to working Imapsync tasks.
-If you were using POP3, it's necessary to review the settings and commence synchronization manually.
+Configurations of accounts using the IMAP protocol are translated to working Imapsync tasks.
+For accounts using POP3, it is necessary to review the settings and commence synchronization manually.
 
 .. rubric:: Configurations excluded from migration
 


### PR DESCRIPTION
Documentation of the migration process of connector to imapsync module

https://github.com/NethServer/dev/issues/6776