### PR TITLE
Update Ejabberd configuration with FQDN and web admin details

### DIFF
--- a/ejabberd.rst
+++ b/ejabberd.rst
@@ -43,7 +43,7 @@ How to configure:
 The Ejabberd administrators are allowed to use the web admin page on port 5280. The ejabberd Web Admin allows to administer some parts of ejabberd using a web browser: 
 accounts, Shared Roster Groups, manage the Mnesia database, create and restore backups, view server statistics, …
 
-The administration page is only available by an HTTP route that you must do manually to http://127.0.0.1:5280. Apply the procedure described in :ref:`traefik-section`
+The administration page is available at `http://127.0.0.1:5280`. To reach it a HTTP route can be created manually, following the procedure described in :ref:`traefik-section`.
 
 Under the Advanced options section, the administrator can also configure:
 


### PR DESCRIPTION
This pull request updates the Ejabberd configuration to include the Fully Qualified Domain Name (FQDN) for user authentication and the web admin details. 
 linked to https://github.com/NethServer/ns8-ejabberd/pull/28