### PR TITLE
Fix the Url of ejabberd admin page

### DIFF
--- a/ejabberd.rst
+++ b/ejabberd.rst
@@ -43,7 +43,7 @@ How to configure:
 The Ejabberd administrators are allowed to use the web admin page on port 5280. The ejabberd Web Admin allows to administer some parts of ejabberd using a web browser: 
 accounts, Shared Roster Groups, manage the Mnesia database, create and restore backups, view server statistics, …
 
-The administration page is available at `http://127.0.0.1:5280`. To reach it a HTTP route can be created manually, following the procedure described in :ref:`traefik-section`.
+The administration page is available at `https://IP_OR_FQDN:5280/admin`.
 
 Under the Advanced options section, the administrator can also configure:
 


### PR DESCRIPTION
The URL of the web admin page is now on the FQDN or IP with TLS encryption.

Refs https://github.com/NethServer/dev/issues/6787