### PR TITLE
Add migration instructions for NethServer 7 to 8

### DIFF
--- a/migration.rst
+++ b/migration.rst
@@ -20,6 +20,9 @@ Also make sure that
 * you have access to your authoritative DNS server:
   you will need to change some DNS records after the migration of
   each application
+* if the source NethServer 7 system has the NethForge repository enabled,
+  enable it under NS8 Repository Settings accordingly. This step is
+  required to migrate SOGo.
 
 The migration procedure will add the source machine as special node of NethServer 8 cluster.
 

--- a/sogo.rst
+++ b/sogo.rst
@@ -28,6 +28,12 @@ Official documentation
 
 Please read `official documentation <https://sogo.nu/files/docs/SOGoInstallationGuide.html>`_ for more informations.
 
+Migration from NethServer 7
+===========================
+
+The application can be migrated from NethServer 7 to NethServer 8, but it requires some manual steps, please refers to the :ref:`migration-section` for more informations.
+The NethForge repository must be enabled in the NS8 cluster before to proceed with the migration.
+
 Configuration
 =============
 

--- a/sogo.rst
+++ b/sogo.rst
@@ -31,8 +31,9 @@ Please read `official documentation <https://sogo.nu/files/docs/SOGoInstallation
 Migration from NethServer 7
 ===========================
 
-The application can be migrated from NethServer 7 to NethServer 8, but it requires some manual steps, please refers to the :ref:`migration-section` for more informations.
-The NethForge repository must be enabled in the NS8 cluster before to proceed with the migration.
+The application can be migrated from NethServer 7 to NethServer 8, but it requires some manual steps. Please refer to the section :ref:`migration-section` for more information.
+
+The NethForge repository must be enabled in the NS8 cluster before proceeding with the migration.
 
 Configuration
 =============


### PR DESCRIPTION
This pull request adds migration instructions for NethServer 7 to 8. It includes a new section in the documentation that explains the manual steps required for the migration process. Additionally, it mentions the need to enable the NethForge repository in the NS8 cluster before proceeding with the migration.

https://github.com/NethServer/dev/issues/6804