### PR TITLE
Add explanation of using local account for fetching emails from remote IMAP account

### DIFF
--- a/imapsync.rst
+++ b/imapsync.rst
@@ -6,12 +6,12 @@ Imapsync
 
 
 
-This module installs Imapsync, an IMAP transfer tool used for copying emails from one IMAP server to the NethServer 8 IMAP server.
-This module can server to many purposes, for example:
+This module installs Imapsync, an IMAP transfer tool used for copying and moving emails from external IMAP servers to a :ref:`Mail server <email-section>` instance.
+This module can serve many purposes. For example:
 
-- if you want to use the local IMAP account as a backup of the remote one.
-- if you want to use the local IMAP account as a combination of several remote ones.
-- if you want to migrate messages from one remote IMAP account to a local one.
+- If you want to use the local IMAP account as a backup for the remote one.
+- If you want to use the local IMAP account as a combination of several remote ones.
+- If you want to migrate messages from one remote IMAP account to a local one.
 
 The task is both recursive and incremental and can be repeated as many times as needed, also you can select the task frequency.
 

--- a/imapsync.rst
+++ b/imapsync.rst
@@ -7,6 +7,11 @@ Imapsync
 
 
 This module installs Imapsync, an IMAP transfer tool. Its purpose is migrating email messages from remote IMAP accounts to a local one.
+But it can used for fetching emails from a remote IMAP account to a local one 
+
+- if you want to use the local account as a backup of the remote one.
+- if you want to use the local account as a combination of several remote ones.
+- ... and many other reasons.
 
 The migration is both recursive and incremental and can be repeated as many times as needed, also you can select the task frequency.
 

--- a/imapsync.rst
+++ b/imapsync.rst
@@ -6,14 +6,14 @@ Imapsync
 
 
 
-This module installs Imapsync, an IMAP transfer tool. Its purpose is migrating email messages from remote IMAP accounts to a local one.
-But it can used for fetching emails from a remote IMAP account to a local one 
+This module installs Imapsync, an IMAP transfer tool used for copying emails from one IMAP server to the NethServer 8 IMAP server.
+This module can server to many purposes, for example:
 
-- if you want to use the local account as a backup of the remote one.
-- if you want to use the local account as a combination of several remote ones.
-- ... and many other reasons.
+- if you want to use the local IMAP account as a backup of the remote one.
+- if you want to use the local IMAP account as a combination of several remote ones.
+- if you want to migrate messages from one remote IMAP account to a local one.
 
-The migration is both recursive and incremental and can be repeated as many times as needed, also you can select the task frequency.
+The task is both recursive and incremental and can be repeated as many times as needed, also you can select the task frequency.
 
 The system administrator of the local NethServer does not need to know the password of the local user because Imapsync access the local user mailbox with administrative permissions. However, the administrator has to know the password of the remote IMAP account, unless the IMAP administrative authentication is implemented also by the remote email server.
 

--- a/mail.rst
+++ b/mail.rst
@@ -12,6 +12,8 @@ The Email module is split into three main parts:
   and `Sieve <https://en.wikipedia.org/wiki/Sieve_(mail_filtering_language)>`_ language to organize it
 * `RSPAMD <https://rspamd.com/>`_: antispam filter, antivirus and attachments blocker
 
+The optionnal :ref:`imapsync-section` module can be installed as a standalone. This module intends to fetch email from an IMAP server to a local IMAP account.
+
 Benefits are:
 
 * complete autonomy in electronic mail management

--- a/mail.rst
+++ b/mail.rst
@@ -12,7 +12,7 @@ The Email module is split into three main parts:
   and `Sieve <https://en.wikipedia.org/wiki/Sieve_(mail_filtering_language)>`_ language to organize it
 * `RSPAMD <https://rspamd.com/>`_: antispam filter, antivirus and attachments blocker
 
-The optionnal :ref:`imapsync-section` module can be installed as a standalone. This module intends to fetch email from an IMAP server to a local IMAP account.
+The optional :ref:`imapsync-section` module can be connected to Mail. It allows scheduling fetch jobs or migrating emails from external IMAP servers to local user mailboxes.
 
 Benefits are:
 


### PR DESCRIPTION
This pull request adds an explanation in the documentation about how to use a local account for fetching emails from a remote IMAP account. It provides information on using the local account as a backup of the remote one or as a combination of several remote accounts. This feature can be useful for various reasons.