### PR TITLE
Add new plugins and update recommended plugins list

### DIFF
--- a/roundcube.rst
+++ b/roundcube.rst
@@ -48,12 +48,13 @@ The plugins that are enabled by default are:
 
 * archive
 * Zip download
+* Manage sieve: manage filters for incoming mail
+* Mark as junk: mark the selected messages as Junk and move them to the configured Junk folder
 
 Recommended plugins:
 
 * New mail notifier
 * Emoticons
 * VCard support
-* Manage sieve: manage filters for incoming mail
-* Mark as junk: mark the selected messages as Junk and move them to the configured Junk folder
 
+The complete list of official plugin could be find at `Roundcube plugins <https://github.com/roundcube/roundcubemail/tree/master/plugins>`_.


### PR DESCRIPTION
- Added a link where to list the offcial plugin included inside the container

- List the plugin included  by default https://github.com/NethServer/ns8-roundcubemail/blob/32e793ddcaf1e863a52289675085f11956cc8ab3/imageroot/actions/configure-module/10EnvRouncubemail#L16


refs: https://github.com/NethServer/dev/issues/6896
