### PR TITLE
Update migration.rst with ns7admin user creation and removal process

### DIFF
--- a/migration.rst
+++ b/migration.rst
@@ -48,7 +48,8 @@ The migration procedure will add NS7 as special node of the NethServer 8 cluster
 
    - ``NS8 admin username`` and ``NS8 admin password``: administrator
      credentials for the leader node. 
-     These credentials are solely used to create the ``ns7admin`` admin account in NS8,
+     These credentials are solely used to create a ``ns7admin1`` admin account in NS8
+     (note that the trailing '1' may actually be any number),
      reserved for the NS7 migration tool. Ensure that this account is automatically
      removed at the end of the migration.
 

--- a/migration.rst
+++ b/migration.rst
@@ -47,10 +47,11 @@ The migration procedure will add NS7 as special node of the NethServer 8 cluster
    - ``NS8 leader node``: the host name or IP address of NethServer 8 cluster leader node
 
    - ``NS8 admin username`` and ``NS8 admin password``: administrator
-     credentials for the leader node. As a best practice, create a
-     dedicated user from the :ref:`administrators-section` page and delete
-     the user once the migration has been completed. Please note that the
-     user must have 2FA disabled.
+     credentials for the leader node. 
+     In NethServer 8, a ``ns7admin`` user is automatically created by the migration process
+     to perform the migration tasks and is removed upon completion. However, after leaving
+     the cluster, it is essential to verify that the ``ns7admin`` user has been correctly
+     removed. If it has not been removed, this must be done manually.
 
    - uncheck the ``TLS validation`` option if the leader node does not have a valid TLS certificate
 

--- a/migration.rst
+++ b/migration.rst
@@ -48,10 +48,9 @@ The migration procedure will add NS7 as special node of the NethServer 8 cluster
 
    - ``NS8 admin username`` and ``NS8 admin password``: administrator
      credentials for the leader node. 
-     In NethServer 8, a ``ns7admin`` user is automatically created by the migration process
-     to perform the migration tasks and is removed upon completion. However, after leaving
-     the cluster, it is essential to verify that the ``ns7admin`` user has been correctly
-     removed. If it has not been removed, this must be done manually.
+     These credentials are solely used to create the ``ns7admin`` admin account in NS8,
+     reserved for the NS7 migration tool. Ensure that this account is automatically
+     removed at the end of the migration.
 
    - uncheck the ``TLS validation`` option if the leader node does not have a valid TLS certificate
 


### PR DESCRIPTION
This pull request updates the `migration.rst` file to explain the process of creating and removing the `ns7admin` user during the migration from NS7 to NS8. The `ns7admin` user is automatically created by the migration process and is removed upon completion. However, it is important to verify that the user has been correctly removed after leaving the cluster. If not, manual removal is required.

https://github.com/NethServer/dev/issues/6994