### PR TITLE
Add note for NethVoice Migration

### DIFF
--- a/migration.rst
+++ b/migration.rst
@@ -71,6 +71,10 @@ The web interface will display the list of all applications installed inside Net
     If NS7 has a remote account provider and an error message is displayed
     instead, see :ref:`migrate-account-provider`.
 
+.. note::
+
+   Before proceeding with the migration of NethVoice, install and configure :ref:`NethVoice Proxy <nethvoice_proxy-section>` on NS8.
+
 #. Choose an application and click on the :guilabel:`Start migration`
    button. In this phase the migration process will install the
    application into the NethServer 8 cluster and start the first data


### PR DESCRIPTION
Added notes in the migration section with the indication to install and configure NethVoice Proxy before proceeding with the migration of NethVoice.