### PR TITLE
Add mail server feature for unknown recipients to migration documentation

### DIFF
--- a/migration.rst
+++ b/migration.rst
@@ -361,5 +361,8 @@ The following configurations are not migrated:
 - System smart host settings, if the NS7 Email app is either not installed
   or not migrated
 
+- The feature ``Accept unknown recipients`` of the mail server that will catch all messages sent to non-existing addresses.(see
+  :ref:`email_domains`)
+
 Additionally, shared folders will not be migrated if NS7 uses a remote
 account provider.


### PR DESCRIPTION
Document the non-migrated feature that accepts messages sent to non-existing addresses in the mail server migration guide.

https://github.com/NethServer/dev/issues/7257