### PR TITLE
fix(ejabberd): Improve TLS certificate handling notes and documentation for Ejabberd

### DIFF
--- a/certificates.rst
+++ b/certificates.rst
@@ -56,6 +56,8 @@ to obtain the certificate at a later time when:
    memory. Do not restart Traefik too often, to avoid incurring in Let's
    Encrypt rate limits.
 
+.. _custom-certificates-section:
+
 Custom certificates
 ===================
 

--- a/ejabberd.rst
+++ b/ejabberd.rst
@@ -105,7 +105,15 @@ Some widespread clients:
 When you configure the client, make sure TLS (or SSL) is enabled.
 Enter the user name and the domain of the machine. 
 
-With TLS capabilities, strictly configured servers or clients could reject connections with your Ejabberd server 
-if the SSL/TLS certificate doesn't match the domain name.
+.. note::
+   With TLS capabilities, strictly configured servers or clients (e.g. Gajim) could reject connections with your Ejabberd server if the SSL/TLS certificate doesn't match the domain name.
+
+This is a common problem with self-signed certificates. The client will refuse to connect to the server because the certificate does not match the Common Name
+
+Possible solutions:
+
+* Disable the certificate check on the client side.
+* Upload a valid certificate to the server (see :ref:`custom-certificates-section`).
+* Request a valid certificate from a trusted authority (e.g. Let's Encrypt). This certificate can be obtained for free with Let's Encrypt.
+
 Also, the certificate should contain two sub-domains ``pubsub.*`` and ``conference.*``.
-This certificate can be obtained for free with Let's Encrypt.


### PR DESCRIPTION
Enhance the documentation by adding a note on TLS certificate issues and provide a reference to the custom certificates section. Include a missing label for better clarity in the documentation.

Refs: https://github.com/NethServer/dev/issues/7408