### PR TITLE
Add manual configuration instructions for Autodiscover and Autoconfig HTTP routes

### DIFF
--- a/webtop.rst
+++ b/webtop.rst
@@ -322,6 +322,19 @@ therefore their names must be associated with a valid TLS certificate.
 - ``autodiscover.example.org``, ``autoconfig.example.org`` must point to
   the public static IP of the **server hosting WebTop**.
 
+To ensure that Autodiscover and Autoconfig requests are directed to the correct WebTop instance,
+you need to set up an HTTP route to the WebTop server. Navigate to :guilabel:`Settings` → :guilabel:`HTTP routes`
+from the  :ref:`proxy page <traefik-section>`. This configuration is necessary for DNS records like
+``autodiscover.example.org`` and ``autoconfig.example.org`` to be properly managed by the WebTop application.
+
+Configure the HTTP route with the following parameters for both Autodiscover and Autoconfig:
+
+- Name: ``autodiscover_webtop`` and ``autoconfig_webtop``
+- Node: Select the node where your WebTop instance is running
+- URL: ``http://127.0.0.1:20001`` (replace 20001 with your WebTop HTTP port if different)
+- Host: ``autodiscover.example.org`` and ``autoconfig.example.org``
+- Request Let's Encrypt certificate: Enable this option if you wish to use a Let's Encrypt certificate (optional)
+
 MX record
 ---------
 


### PR DESCRIPTION
Include detailed steps for setting up HTTP routes to direct Autodiscover and Autoconfig requests to the correct WebTop instance. Provide parameters for configuration to ensure proper management of DNS records.