### PR TITLE
Imapsync known limitation with dovecot vacation plugin

### DIFF
--- a/imapsync.rst
+++ b/imapsync.rst
@@ -153,3 +153,8 @@ Known limitations
 
 - Imapsync does not integrate with :ref:`Piler <piler-section>`, meaning
   that messages transferred via Imapsync are not archived.
+
+- Messages copied by Imapsync do not trigger the Dovecot vacation (out-of-office)
+  auto-reply. If the local account has the vacation plugin enabled, remote
+  senders will not receive an automatic vacation response, since messages
+  delivered via Imapsync are not processed by the sieve filter.


### PR DESCRIPTION
This pull request adds a clarification to the documentation about how Imapsync interacts with Dovecot's vacation (out-of-office) auto-reply functionality.

- Documentation update: Added a note to the `Known limitations` section in `imapsync.rst` explaining that messages copied by Imapsync do not trigger Dovecot's vacation auto-reply, since these messages are not processed by the sieve filter.

https://github.com/NethServer/dev/issues/7592
