### PR TITLE
fix(subscription): cluster backup upload for nscom

### DIFF
--- a/subscription.rst
+++ b/subscription.rst
@@ -37,7 +37,7 @@ enabled:
 - Upload of leader node inventory
 - Scheduled updates for node operating systems, core components, and
   applications
-- Upload of cluster backup (Enterprise only)
+- Upload of cluster backup
 
 Regarding software repositories, only the ``subscription`` repository
 remains enabled.


### PR DESCRIPTION
The cluster agent now uploads the cluster backup also for system subscribed to my.nethserver.com.

NethServer/dev#7594