### PR TITLE
fix: deprecate MinIO in favor of RustFS

### DIFF
--- a/backup.rst
+++ b/backup.rst
@@ -48,7 +48,7 @@ destination` button, and choose a provider. Supported providers are:
 * `Backblaze B2`_
 * `Amazon S3`_
 * `Azure Blob Storage`_
-* Generic S3, like :ref:`MinIO <minio-section>`
+* Generic S3, like :ref:`RustFS <rustfs-section>`
 * Windows file share, through SMB2/3 protocols
 * :ref:`Local storage <local-storage>`, attached to a node of the cluster
 

--- a/index.rst
+++ b/index.rst
@@ -59,7 +59,6 @@ NethServer 8 administrator manual
    collabora
    mattermost
    ejabberd
-   minio
    crowdsec
    imapsync
    nethsecurity_controller

--- a/minio.rst
+++ b/minio.rst
@@ -1,8 +1,14 @@
+:orphan:
+
 .. _minio-section:
 
 =====
 MinIO
 =====
+
+.. warning::
+
+   MinIO has been replaced by RustFS. Existing MinIO installations are advised to migrate to RustFS. Please refer to :ref:`rustfs-section` documentation.
 
 `MinIO <https://min.io/>`_ offers high-performance, S3 compatible object storage.
 


### PR DESCRIPTION
Update the documentation to inform users that MinIO has been replaced by RustFS. A warning message has been added at the top of the `minio.rst` file to direct users to the RustFS documentation.