### PR TITLE
Explain generated root password

### DIFF
--- a/docs/administrator-manual/installation/install.md
+++ b/docs/administrator-manual/installation/install.md
@@ -44,14 +44,15 @@ Virtualization platform-specific notes:
 - For VMWare ESXi 8+, add a hard disk with existing image and select *IDE controller 1 (Master)*.
 - On Proxmox, for maximum performance, select `host` as the CPU type. Avoid "kvm64", because Rocky Linux image does not support it. Refer to [Proxmox documentation](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) for further details about CPU selection.
 
-Start the NS8 image within your virtualization platform. If Cloud-init does not find a network configuration, it attempts to obtain one via DHCP. After a few seconds, the system console displays a login prompt showing the assigned IP address.
+Start the NS8 image within your virtualization platform. If Cloud-init
+does not find a network configuration, it attempts to obtain one via DHCP.
+In this case, remember to disable DHCP and assign a static IP address as
+explained by the warning below.
 
-Default OS administrative credentials are
-
-- Username: `root`
-- Password: `Nethesis,1234`
-
-Log in using the default credentials. On the first login, you will be prompted to change the root password.
+After a few seconds, the system console displays a login prompt showing
+the assigned IP address and the initial random root password. Log in as
+`root` using the displayed initial password. You will be prompted to
+change it immediately.
 
 SSH access is disabled for root. To obtain administrative SSH access, create a personal user account in the `wheel` group and set a password. For example, run the following commands and enter the desired password:
 

--- a/docs/tutorial/os_network.md
+++ b/docs/tutorial/os_network.md
@@ -36,3 +36,6 @@ This is a summary of keyboard functions:
 To apply the changes restart NetworkManager:
 
     systemctl restart NetworkManager
+
+If possible, reboot the node to be sure the new network settings persist across
+reboots.

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/installation/install.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/installation/install.md
@@ -42,14 +42,15 @@ Note specifiche per le piattaforme di virtualizzazione:
 - Per VMWare ESXi 8+, aggiungi un disco rigido con immagine esistente e seleziona *IDE controller 1 (Master)*.
 - Su Proxmox, per ottenere prestazioni massime, seleziona `host` come tipo di CPU. Evita "kvm64", poiché l'immagine Rocky Linux non lo supporta. Consulta la [documentazione di Proxmox](https://pve.proxmox.com/pve-docs/chapter-qm.html#qm_cpu) per ulteriori dettagli sulla selezione della CPU.
 
-Avvia l'immagine NS8 all'interno della tua piattaforma di virtualizzazione. Se Cloud-init non trova una configurazione di rete, tenterà di ottenerne una tramite DHCP. Dopo alcuni secondi, la console di sistema mostrerà un prompt di accesso con l'indirizzo IP assegnato.
+Avviare l'immagine NS8 all'interno della piattaforma di virtualizzazione. Se Cloud-init
+non trova una configurazione di rete, tenterà di ottenerne una tramite DHCP.
+In questo caso, ricordarsi di disabilitare il DHCP e assegnare un indirizzo IP statico come
+spiegato nell'avviso riportato di seguito.
 
-Le credenziali amministrative predefinite del sistema operativo sono:
-
-- Nome utente: `root`
-- Password: `Nethesis,1234`
-
-Accedi utilizzando le credenziali predefinite. Al primo accesso, ti verrà richiesto di cambiare la password di root.
+Dopo alcuni secondi, la console di sistema visualizzerà un prompt di login che mostra
+l'indirizzo IP assegnato e la password iniziale casuale per l'utente root. Accedere come
+`root` utilizzando la password iniziale visualizzata. Verrà richiesto di
+modificarla immediatamente.
 
 L'accesso SSH per root è disabilitato. Per ottenere l'accesso amministrativo SSH, crea un account utente personale nel gruppo `wheel` e imposta una password. Ad esempio, esegui i seguenti comandi e inserisci la password desiderata:
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/tutorial/os_network.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/tutorial/os_network.md
@@ -36,3 +36,5 @@ Questo è un riepilogo delle funzioni da tastiera:
 Per applicare le modifiche, riavvia NetworkManager:
 
     systemctl restart NetworkManager
+
+Se possibile, riavviare il nodo per assicurarsi che le nuove impostazioni di rete persistano dopo i riavvii.


### PR DESCRIPTION
The prebullt image uses a automatically generated random root password to improve security. It needs to be documented.

NethServer/dev#7673