### PR TITLE
docs(os_updates): expand OS updates page with manual steps and Nethesis mirror

### DIFF
--- a/os_updates.rst
+++ b/os_updates.rst
@@ -4,22 +4,134 @@
 Operating system updates
 ========================
 
-NethServer 8 is installed on top of Linux distributions and strives to
-preserve default configurations as much as possible. The system
-administrator has the flexibility to choose how operating system updates
-are applied.
+NethServer 8 runs on top of standard Linux distributions and leaves most
+operating system configuration under the control of the system administrator.
 
-It is generally advisable to apply operating system updates promptly. If
-you have an active subscription, updates are automatically applied as
-described in the :ref:`scheduled-updates` section. Otherwise, consult your
-distribution documentation for guidance:
+The system administrator can decide how and when operating system updates
+are applied. In general, installing updates promptly is recommended.
 
-* `Rocky Linux/AlmaLinux <https://docs.rockylinux.org/guides/security/dnf_automatic/>`_
-* `Debian <https://wiki.debian.org/UnattendedUpgrades>`_
+If you have an active subscription, operating system updates can be applied
+automatically as described in the :ref:`scheduled-updates` section.
 
-CentOS Stream is regarded as a preview of the next stable RHEL release.
-Updates may introduce new software versions that could potentially cause
-unexpected issues. To enable automatic updates on CentOS Stream, simply
-follow the same instructions as outlined for Rocky Linux.
+Automatic updates
+=================
 
-For updates to core and modules, refer to :ref:`updates-section`.
+To enable automatic operating system updates, refer to your distribution documentation:
+
+* Rocky Linux / AlmaLinux and similar: `Patching servers with dnf-automatic`_
+* Debian: `Periodic updates`_
+
+.. _`Patching servers with dnf-automatic`: https://docs.rockylinux.org/guides/security/dnf_automatic/
+.. _`Periodic updates`: https://wiki.debian.org/PeriodicUpdates
+
+.. note::
+
+  CentOS Stream follows a rolling-release model and may introduce newer
+  software versions that can lead to unexpected behavior. If enabling
+  automatic updates, follow the same approach as for Rocky Linux.
+
+.. note::
+
+  For updates to NS8 core and modules, refer to :ref:`updates-section`.
+
+Manual updates
+==============
+
+The command to update the operating system depends on the distribution:
+
+* APT_ (Debian):
+
+  ``apt update && apt upgrade -y``
+
+* DNF_ (Rocky Linux, AlmaLinux and similar):
+
+  ``dnf update -y``
+
+.. _APT: https://www.debian.org/doc/manuals/debian-faq/pkgtools.en.html#apt-get
+.. _DNF: https://docs.rockylinux.org/9/guides/package_management/dnf_package_manager/#update-and-upgrade
+
+Node reboot
+===========
+
+Some updates, such as kernel updates, may require a node reboot to take effect.
+
+After completing updates (automatic or manual), reboot the system:
+
+::
+
+  shutdown -r now
+
+To schedule a reboot in 30 minutes:
+
+::
+
+  shutdown -r +30 "System reboot in 30 minutes"
+
+To cancel a scheduled reboot:
+
+::
+
+  shutdown -c
+
+.. _neth-mirror:
+
+Nethesis-managed Rocky Linux mirror
+====================================
+
+When NS8 is installed on Rocky Linux, the DNF configuration is adjusted to
+use mirrors managed by Nethesis_.
+
+.. _Nethesis: https://www.nethesis.it
+
+* ns-appstream (NS8 Rocky Linux 9 - AppStream)
+* ns-baseos (NS8 Rocky Linux 9 - BaseOS)
+
+These mirrors are synchronized weekly with the official Rocky Linux
+repositories (Friday at 21:00 UTC) and act as a controlled snapshot of the
+upstream content.
+
+This delay allows potential breaking changes in upstream repositories to
+be identified and blocked before they reach production systems.
+
+The mirrors are available to all NS8 installations, regardless of
+subscription status.
+
+With an active subscription, updates are progressively rolled out from the
+latest snapshot in a staged manner. This staged rollout reduces the risk
+of widespread issues by gradually exposing updates across environments.
+
+In case of an important security fix or for any other exceptional need,
+administrators can temporarily bypass or permanently disable the
+Nethesis-managed mirrors in order to access the official Rocky Linux
+repositories.
+
+Single update run from official repositories:
+
+::
+
+  dnf --enablerepo=baseos,appstream --disablerepo=ns-baseos,ns-appstream update
+
+Check the current repositories status:
+
+::
+
+  dnf repolist -v
+
+Permanently switch to official Rocky Linux repositories:
+
+::
+
+  dnf config-manager --save --set-disabled ns-appstream ns-baseos
+  dnf config-manager --save --set-enabled appstream baseos
+
+.. warning::
+
+  Switching repositories bypasses the staged update mechanism provided by
+  Nethesis-managed mirrors. Use this only when strictly necessary.
+
+Restore Nethesis-managed mirrors (default configuration):
+
+::
+
+  dnf config-manager --save --set-enabled ns-appstream ns-baseos
+  dnf config-manager --save --set-disabled appstream baseos

--- a/os_updates.rst
+++ b/os_updates.rst
@@ -10,8 +10,18 @@ operating system configuration under the control of the system administrator.
 The system administrator can decide how and when operating system updates
 are applied. In general, installing updates promptly is recommended.
 
-If you have an active subscription, operating system updates can be applied
-automatically as described in the :ref:`scheduled-updates` section.
+If you have an *active subscription*, the default operating system update
+policy applies the updates automatically as described in the
+:ref:`scheduled-updates` section.
+
+.. warning::
+
+  On Rocky Linux, do not enable `dnf-automatic` or any other automatic
+  update mechanism if you have an
+  :ref:`active subscription <subscription-section>`. Use the scheduled
+  updates feature instead. Running multiple update mechanisms may result
+  in updates being applied outside the intended rollout schedule.
+
 
 Automatic updates
 =================
@@ -39,13 +49,13 @@ Manual updates
 
 The command to update the operating system depends on the distribution:
 
-* APT_ (Debian):
+* APT_ (Debian): ::
 
-  ``apt update && apt upgrade -y``
+    apt update && apt upgrade
 
-* DNF_ (Rocky Linux, AlmaLinux and similar):
+* DNF_ (Rocky Linux, AlmaLinux and similar): ::
 
-  ``dnf update -y``
+    dnf update
 
 .. _APT: https://www.debian.org/doc/manuals/debian-faq/pkgtools.en.html#apt-get
 .. _DNF: https://docs.rockylinux.org/9/guides/package_management/dnf_package_manager/#update-and-upgrade
@@ -83,8 +93,8 @@ use mirrors managed by Nethesis_.
 
 .. _Nethesis: https://www.nethesis.it
 
-* ns-appstream (NS8 Rocky Linux 9 - AppStream)
-* ns-baseos (NS8 Rocky Linux 9 - BaseOS)
+* ``ns-appstream`` (NS8 Rocky Linux 9 - AppStream)
+* ``ns-baseos`` (NS8 Rocky Linux 9 - BaseOS)
 
 These mirrors are synchronized weekly with the official Rocky Linux
 repositories (Friday at 21:00 UTC) and act as a controlled snapshot of the
@@ -105,17 +115,18 @@ administrators can temporarily bypass or permanently disable the
 Nethesis-managed mirrors in order to access the official Rocky Linux
 repositories.
 
+Check the upstream repository status against the Nethesis mirror:
+
+::
+
+  dnf repolist -v --repo=*baseos
+  dnf repolist -v --repo=*appstream
+
 Single update run from official repositories:
 
 ::
 
   dnf --enablerepo=baseos,appstream --disablerepo=ns-baseos,ns-appstream update
-
-Check the current repositories status:
-
-::
-
-  dnf repolist -v
 
 Permanently switch to official Rocky Linux repositories:
 

--- a/software_center.rst
+++ b/software_center.rst
@@ -243,8 +243,9 @@ NethServer 8 can handle two different types of updates:
 :ref:`Operating system updates <os_updates-section>` are demanded to the
 underlying Linux distribution.
 
-If you have an active subscription, available updates are applied
-automatically as described in :ref:`scheduled-updates`.
+If you have an active subscription, available updates (including operating
+system updates) are applied automatically as described in
+:ref:`scheduled-updates`.
 
 .. _core_updates-section:
 

--- a/subscription.rst
+++ b/subscription.rst
@@ -35,8 +35,8 @@ enabled:
 - Remote support by Nethesis
 - Resources :ref:`monitoring and alerting <metrics-section>`
 - Upload of leader node inventory
-- Scheduled updates for node operating systems, core components, and
-  applications
+- :ref:`Scheduled updates <scheduled-updates>` for node operating systems,
+  core components, and applications
 - Upload of cluster backup
 
 Regarding software repositories, only the ``subscription`` repository
@@ -119,6 +119,15 @@ and server resources. The updates include:
 
 - **Applications**: Updates are also sourced from the ``subscription``
   repository.
+
+.. note::
+
+   With an active subscription, do not use custom procedures to update
+   the operating system, core components, or applications. This includes
+   Cockpit's software update feature and ``dnf-automatic``, which may
+   run uncontrolled updates in the background. Such procedures create an
+   unsupported configuration and may cause system instability. Let the
+   scheduled task handle all updates
 
 Managed repositories follow a conservative update policy to ensure
 stability and thorough testing of updates, making them suitable for

--- a/subscription.rst
+++ b/subscription.rst
@@ -112,7 +112,7 @@ and server resources. The updates include:
 - **Operating system**: Updates are sourced from the DNF repositories
   labeled ``ns-baseos`` and ``ns-appstream``. These repositories provide
   delayed snapshots of Rocky Linux repositories to avoid distributing
-  updates that could cause unexpected issues.
+  updates that could cause unexpected issues (see :ref:`neth-mirror`).
 
 - **Core components**: Updates are fetched from the ``subscription``
   repository.

--- a/system_requirements.rst
+++ b/system_requirements.rst
@@ -30,17 +30,22 @@ Linux distribution
 Install NS8 on a clean Linux server distribution, avoiding installation on
 desktop systems or servers already running other services.
 
-Linux distributions and versions with Nethesis :ref:`Subscription
-<subscription-section>` (including "Enterprise" plan) support:
+NS8 is compatible with `Rocky Linux`_ 9 and RHEL 9 derivative
+distributions, such as AlmaLinux or CentOS Stream 9,
+as well as Debian_ 13.
 
-- `Rocky Linux <https://rockylinux.org/>`_ 9
+You may find volunteer support in the NethServer community public forum
+for all compatible distributions.
 
-Linux distributions and versions with NethServer's community support:
+The :ref:`Nethesis Subscription <subscription-section>` (including the
+"Enterprise" plan) is available only for **Rocky Linux 9**.
 
-- `Rocky Linux <https://rockylinux.org/>`_ 9
-- `CentOS Stream <https://www.centos.org/centos-stream/>`_ 9
-- `AlmaLinux <https://almalinux.org>`_ 9
-- `Debian <https://www.debian.org/>`_ 12, 13
+.. _`Rocky Linux`: https://rockylinux.org/
+.. _Debian: https://www.debian.org/
+
+Read the section :ref:`os_updates-section` to keep the Linux distribution
+up to date and to learn more about the DNF repositories managed by
+Nethesis, which are enabled by default on Rocky Linux.
 
 .. _swap-reqs:
 
@@ -188,7 +193,7 @@ over TCP port 443.
    "Cluster VPN and node communication", "<leader node address>", "55820", "UDP", "Inter-node VPN and cluster traffic"
    "Cluster-admin leader API", "<leader node address>", "443", "HTTPS", "Join a new worker to the cluster"
    "OS and NS8 repositories mirror resolution", "mirrorlist.nethserver.org", "80", "HTTP", "Used to resolve Rocky Linux and NS8 mirrors"
-   "Rocky Linux DNF repositories", "u4.nethesis.it, u5.nethesis.it", "443", "HTTPS", "Rocky Linux BaseOS and AppStream updates"
+   "Rocky Linux DNF repositories", "u4.nethesis.it, u5.nethesis.it", "443", "HTTPS", "Nethesis-managed mirror of BaseOS and AppStream repositories"
    "TLS certificate issuance", "acme-v02.api.letsencrypt.org", "443", "HTTPS", "Let's Encrypt ACME v2 endpoint"
    "NS8 core and updates repository", "distfeed.nethserver.org", "443", "HTTPS", "Core updates and patches"
    "Community application repository", "forge.nethserver.org", "443", "HTTPS", "Optional community modules"


### PR DESCRIPTION


Add "Automatic updates", "Manual updates", "Node reboot", and "Nethesis-managed Rocky Linux mirror" sections.

Clarify in software_center.rst that scheduled updates cover OS updates as well as core and module updates.