### PR TITLE
docs: note pre-built image has swap preconfigured

### DIFF
--- a/system_requirements.rst
+++ b/system_requirements.rst
@@ -59,6 +59,9 @@ workload.
 
 .. __: https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/managing_storage_devices/getting-started-with-swap_managing-storage-devices#recommended-system-swap-space_getting-started-with-swap
 
+The :ref:`Rocky Linux pre-built image <install_image-section>` already
+provides a 4 GB swap file configured as default.
+
 .. _static-ip-reqs:
 
 Static IP address


### PR DESCRIPTION
The Rocky Linux pre-built image already provides a 4 GB swap file configured as default. Add a note in the swap space section of system requirements to inform users who install from that image.