### PR TITLE
fix(translation-sync-agent): handle missing last workflow commit in translation sync

### DIFF
--- a/.github/workflows/sync-translations.yml
+++ b/.github/workflows/sync-translations.yml
@@ -82,8 +82,13 @@ jobs:
           
           if [ -n "$LAST_WORKFLOW_COMMIT" ]; then
             echo "✅ Found last workflow execution at commit: $LAST_WORKFLOW_COMMIT"
-            # Use the commit after the last processed one as the range start for processing
-            COMMITS_TO_PROCESS_RANGE="$LAST_WORKFLOW_COMMIT..HEAD"
+            # Verify the commit still exists locally (may be gone after force-push/rebase/squash)
+            if git cat-file -e "$LAST_WORKFLOW_COMMIT" 2>/dev/null; then
+              COMMITS_TO_PROCESS_RANGE="$LAST_WORKFLOW_COMMIT..HEAD"
+            else
+              echo "⚠️  Commit not found in local history (history rewritten?), falling back to full PR range"
+              COMMITS_TO_PROCESS_RANGE="$MERGE_BASE..HEAD"
+            fi
           else
             echo "⚠️  No previous workflow execution found, processing all commits"
             COMMITS_TO_PROCESS_RANGE="$MERGE_BASE..HEAD"


### PR DESCRIPTION
This pull request improves the reliability of the commit range calculation in the `sync-translations.yml` workflow by handling cases where the last processed commit no longer exists in the local history (e.g., after a force-push, rebase, or squash). The main change ensures that the workflow gracefully falls back to a safe commit range when history has been rewritten.

**Workflow robustness improvements:**

* Added a check to verify that `LAST_WORKFLOW_COMMIT` exists in the local repository before using it as the range start; if the commit is missing (due to history rewrite), the workflow now falls back to using the full PR range (`$MERGE_BASE..HEAD`).