### PR TITLE
docs: add NS8 8.9 release notes

### DIFF
--- a/docs/administrator-manual/about/release_notes.md
+++ b/docs/administrator-manual/about/release_notes.md
@@ -13,7 +13,12 @@ NethServer 8 releases
 
 **Milestone 8.9**
 
-- **New centralized backup architecture** \[Core 3.20.0\] -- Backup scheduling and execution have moved from individual applications to the node level: a node agent now runs application backups sequentially according to node-level schedules, instead of many per-app timers firing in parallel, reducing peak CPU/memory usage during backup runs. All backup destinations are now accessed through Rclone via a node-level gateway, replacing the previous mix of direct Restic and Rclone-behind-Restic logic. This enables a new **Rclone-compatible provider** destination type, accepting a raw `rclone.conf` for any provider supported by Rclone; the Azure Blob Storage provider has been removed in favor of this generic option. Adding or editing a destination now validates that at least one cluster node can reach it; during a backup run, a node that cannot reach the destination directly relays data through the leader node, then other worker nodes, until a working route is found. Applications restored via disaster recovery keep their original backup schedules. See [Backup destination](../configuration/backup.md#backup-destination).
+- **New centralized backup architecture** \[Core 3.20.0\] -- Backup handling has been redesigned around the cluster node rather than individual applications. See [Backup destination](../configuration/backup.md#backup-destination).
+  - More secure: destination passwords are isolated from applications and only accessible with special privileges.
+  - Schedule conflicts are detected and retried automatically within a one-hour window.
+  - On multi-node clusters, nodes can route backup traffic through other nodes, making on-premise destinations reachable from cloud nodes.
+  - Every node validates its own connectivity and permissions to a destination, not just the leader.
+  - Destinations can be fine-tuned with a custom Rclone configuration, enabling advanced options (e.g. skipping TLS certificate validation) and new types such as SFTP and WebDAV.
 
 - **Abort running tasks with a safer confirmation** \[Core 3.20.0\] -- Long-running tasks, including application restore, can be aborted from the UI. The confirmation step was redesigned to prevent accidental clicks that could interrupt an important operation, such as a restore or clone in progress.
 

--- a/docs/administrator-manual/about/release_notes.md
+++ b/docs/administrator-manual/about/release_notes.md
@@ -9,6 +9,48 @@ NethServer 8 releases
 - List of [known bugs](https://github.com/NethServer/dev/issues?q=is%3Aissue%20is%3Aopen%20type%3Abug%20project%3ANethServer%2F8) on GitHub
 - Discussions around [possible bugs](http://community.nethserver.org/c/bug) on our public forum
 
+## Major changes on 2026-06-30
+
+**Milestone 8.9**
+
+- **New centralized backup architecture** \[Core 3.20.0\] -- Backup scheduling and execution have moved from individual applications to the node level: a node agent now runs application backups sequentially according to node-level schedules, instead of many per-app timers firing in parallel, reducing peak CPU/memory usage during backup runs. All backup destinations are now accessed through Rclone via a node-level gateway, replacing the previous mix of direct Restic and Rclone-behind-Restic logic. This enables a new **Rclone-compatible provider** destination type, accepting a raw `rclone.conf` for any provider supported by Rclone; the Azure Blob Storage provider has been removed in favor of this generic option. Adding or editing a destination now validates that at least one cluster node can reach it; during a backup run, a node that cannot reach the destination directly relays data through the leader node, then other worker nodes, until a working route is found. Applications restored via disaster recovery keep their original backup schedules. See [Backup destination](../configuration/backup.md#backup-destination).
+
+- **Abort running tasks with a safer confirmation** \[Core 3.20.0\] -- Long-running tasks, including application restore, can be aborted from the UI. The confirmation step was redesigned to prevent accidental clicks that could interrupt an important operation, such as a restore or clone in progress.
+
+- **Free disk space shown during node selection** \[Core 3.20.0\] -- When installing, cloning, or restoring an application, the node selection step now shows the free disk space of the root filesystem for every node, not only for nodes with an additional volume.
+
+- **Restricted shell for module service users** \[Core 3.20.0\] -- Newly installed application modules now assign `/sbin/nologin` as the default shell for their service user, reducing the attack surface of interactive logins while `runagent` continues to work as before.
+
+- **Random initial root password on pre-built images** \[Core 3.20.0\] -- Pre-built NS8 images (.qcow2/.vmdk) no longer ship with the well-known default root password. A random password is generated at first boot and displayed on the console/MOTD until it is changed. See [Install](../installation/install.md).
+
+- **More resilient pre-built image bootstrap** \[Core 3.20.0\] -- Pre-built images now finish the local Traefik setup (secrets and certificate generation) at first boot even if the network is temporarily unavailable, and the `Create cluster` action handles network/DNS validation failures more gracefully.
+
+- **Logging of outgoing system notification emails** \[Core 3.19.0\] -- The `ns8-sendmail` command, used to deliver password-expiration and other system notifications, now logs a structured record (subject, sender, first recipient, remote server, SMTP status) for each message it submits.
+
+- **IPv6 support in HTTP routes allow list** \[Core 3.18.4\] -- The `Allow access from` restriction on HTTP routes now accepts IPv6 addresses and networks in addition to IPv4.
+
+- **Password never expires for OpenLDAP users** \[OpenLDAP 2.7.0\] -- The "Password never expires" option, previously available only for Active Directory, can now be enabled for individual OpenLDAP users too, both from cluster-admin and the user portal. See [User and groups](../installation/user_domains.md#user_groups-section).
+
+- **Password expiration API for the user portal** \[OpenLDAP 2.7.0, Samba 3.4.6\] -- OpenLDAP and Samba account providers expose a new `get-password-expiration` user-portal API endpoint, letting client applications query a logged-in user's own password expiration status.
+
+- **Spamhaus DQS support in Rspamd** \[Mail 1.7.9\] -- The Mail application can now use Spamhaus's Data Query Service (DQS), an alternative to the public DNSBL protocol that requires a registered token and offers better performance and fewer fair-use restrictions.
+
+- **Sender blocklist for Rspamd** \[Mail 1.7.10\] -- The Mail application's Rspamd configuration adds new maps to block incoming mail by sender TLD, exact domain, domain suffix, or full email address, configurable from the Rspamd UI configuration page.
+
+- **WebTop updates** \[WebTop 1.5.6\] -- WebTop was updated to upstream release 5.32.0, adding a "Remember me" option on the login page. The one-time-password login field no longer uses a password-type input, avoiding unwanted "save password" browser prompts.
+
+- **Nextcloud 33** \[Nextcloud 1.7.0\] -- The Nextcloud application was upgraded to major version 33.
+
+- **Piler volume management and persistent custom configuration** \[Piler 1.2.1, 1.2.2\] -- The Piler email archiving application now supports NS8 volume management, allowing its storage to be placed on an additional disk during install, clone, or restore. A `config-site.php.local` override template can also be used to persist custom `config-site.php` changes across module updates and UI saves.
+
+- **CrowdSec notification wording fix** \[CrowdSec 1.1.4\] -- Email notifications about CrowdSec ban decisions now use correct singular/plural wording instead of always using the plural form.
+
+- **Grafana dashboard for CrowdSec** \[CrowdSec 1.1.6\] -- A Grafana dashboard with a Prometheus exporter for CrowdSec metrics is now available through the Metrics application.
+
+- **Enterprise alerts forwarded to my.nethesis.it** \[Metrics 1.3.0\] -- Clusters with an active Enterprise subscription now automatically forward Metrics/Alertmanager alerts to `my.nethesis.it`, where they appear in the subscription's Alerts page.
+
+- **Other application updates** -- Dnsmasq 1.3.3, Mattermost 2.4.5, Loki 1.4.5, Matrix 0.0.5.
+
 ## Major changes on 2026-03-27
 
 **Milestone 8.8**

--- a/docs/administrator-manual/about/release_notes.md
+++ b/docs/administrator-manual/about/release_notes.md
@@ -18,15 +18,20 @@ NethServer 8 releases
   - Schedule conflicts are detected and retried automatically within a one-hour window.
   - On multi-node clusters, nodes can route backup traffic through other nodes, making on-premise destinations reachable from cloud nodes.
   - Every node validates its own connectivity and permissions to a destination, not just the leader.
-  - Destinations can be fine-tuned with a custom Rclone configuration, enabling advanced options (e.g. skipping TLS certificate validation) and new types such as SFTP and WebDAV.
+  - Destinations can be fine-tuned with a custom Rclone configuration, enabling advanced options (e.g. skipping TLS certificate validation) and new types such as SFTP and WebDAV; the Azure Blob Storage destination type has been removed in favor of this.
+  - Applications restored via disaster recovery keep their original backup schedules.
 
-- **Abort running tasks with a safer confirmation** \[Core 3.20.0\] -- Long-running tasks, including application restore, can be aborted from the UI. The confirmation step was redesigned to prevent accidental clicks that could interrupt an important operation, such as a restore or clone in progress.
+- **Abort running tasks with a safer confirmation** \[Core 3.20.0\] -- Some long-running tasks, including application restore, can be aborted from the UI. The confirmation step was redesigned to prevent accidental clicks that could interrupt an important operation, such as a restore or clone in progress.
 
 - **Free disk space shown during node selection** \[Core 3.20.0\] -- When installing, cloning, or restoring an application, the node selection step now shows the free disk space of the root filesystem for every node, not only for nodes with an additional volume.
 
-- **Restricted shell for module service users** \[Core 3.20.0\] -- Newly installed application modules now assign `/sbin/nologin` as the default shell for their service user, reducing the attack surface of interactive logins while `runagent` continues to work as before.
+- **Restricted shell for module service users** \[Core 3.20.0\] -- Newly installed application modules now assign `/sbin/nologin` as the default shell for their service user, reducing the attack surface of interactive logins while `runagent` continues to work as before. Existing installations can be manually hardened with this command[^nologin]:
 
-- **Random initial root password on pre-built images** \[Core 3.20.0\] -- Pre-built NS8 images (.qcow2/.vmdk) no longer ship with the well-known default root password. A random password is generated at first boot and displayed on the console/MOTD until it is changed. See [Install](../installation/install.md).
+      runagent -l | xargs -l -t -r -- usermod -s /sbin/nologin
+
+[^nologin]: [Change shell to nologin | NS8 dev manual](https://nethserver.github.io/ns8-core/modules/rootless_rootfull/#unix-user)
+
+- **Random initial root password on pre-built images** \[Core 3.20.0\] -- Pre-built NS8 images (.qcow2/.vmdk) no longer ship with the well-known default root password. A random password is generated at first boot and displayed on the console/MOTD until it is changed. See [Install](../installation/install.md#install_image-section).
 
 - **More resilient pre-built image bootstrap** \[Core 3.20.0\] -- Pre-built images now finish the local Traefik setup (secrets and certificate generation) at first boot even if the network is temporarily unavailable, and the `Create cluster` action handles network/DNS validation failures more gracefully.
 
@@ -36,11 +41,9 @@ NethServer 8 releases
 
 - **Password never expires for OpenLDAP users** \[OpenLDAP 2.7.0\] -- The "Password never expires" option, previously available only for Active Directory, can now be enabled for individual OpenLDAP users too, both from cluster-admin and the user portal. See [User and groups](../installation/user_domains.md#user_groups-section).
 
-- **Password expiration API for the user portal** \[OpenLDAP 2.7.0, Samba 3.4.6\] -- OpenLDAP and Samba account providers expose a new `get-password-expiration` user-portal API endpoint, letting client applications query a logged-in user's own password expiration status.
+- **Experimental Spamhaus DQS support in Rspamd** \[Mail 1.7.9\] -- The Mail application can now use Spamhaus's Data Query Service (DQS), an alternative to the public DNSBL protocol that requires a registered token and offers better performance and fewer fair-use restrictions. See [Mail README notes](https://github.com/NethServer/ns8-mail#rspamd-plugin-for-spamhaus-dqs).
 
-- **Spamhaus DQS support in Rspamd** \[Mail 1.7.9\] -- The Mail application can now use Spamhaus's Data Query Service (DQS), an alternative to the public DNSBL protocol that requires a registered token and offers better performance and fewer fair-use restrictions.
-
-- **Sender blocklist for Rspamd** \[Mail 1.7.10\] -- The Mail application's Rspamd configuration adds new maps to block incoming mail by sender TLD, exact domain, domain suffix, or full email address, configurable from the Rspamd UI configuration page.
+- **Sender blocklist for Rspamd** \[Mail 1.7.10\] -- The Mail application's Rspamd configuration adds new maps to block incoming mail by sender TLD, exact domain, domain suffix, or full email address, configurable from the [Rspamd web interface](../applications/mail.md#rspamd-web-interface).
 
 - **WebTop updates** \[WebTop 1.5.6\] -- WebTop was updated to upstream release 5.32.0, adding a "Remember me" option on the login page. The one-time-password login field no longer uses a password-type input, avoiding unwanted "save password" browser prompts.
 
@@ -51,8 +54,6 @@ NethServer 8 releases
 - **CrowdSec notification wording fix** \[CrowdSec 1.1.4\] -- Email notifications about CrowdSec ban decisions now use correct singular/plural wording instead of always using the plural form.
 
 - **Grafana dashboard for CrowdSec** \[CrowdSec 1.1.6\] -- A Grafana dashboard with a Prometheus exporter for CrowdSec metrics is now available through the Metrics application.
-
-- **Enterprise alerts forwarded to my.nethesis.it** \[Metrics 1.3.0\] -- Clusters with an active Enterprise subscription now automatically forward Metrics/Alertmanager alerts to `my.nethesis.it`, where they appear in the subscription's Alerts page.
 
 - **Other application updates** -- Dnsmasq 1.3.3, Mattermost 2.4.5, Loki 1.4.5, Matrix 0.0.5.
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/about/release_notes.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/about/release_notes.md
@@ -8,6 +8,55 @@ Rilasci di NethServer 8
 
 - Elenco dei [bug conosciuti](https://github.com/NethServer/dev/issues?q=is%3Aissue%20is%3Aopen%20type%3Abug%20project%3ANethServer%2F8) su GitHub
 - Discussioni sui [possibili bug](http://community.nethserver.org/c/bug) nel nostro forum pubblico
+
+## Modifiche principali del 30-06-2026
+
+**Milestone 8.9**
+
+- **Nuova architettura di backup centralizzata** \[Core 3.20.0\] -- La gestione dei backup è stata riprogettata attorno al nodo del cluster piuttosto che alle singole applicazioni. Vedere [Destinazione di backup](../configuration/backup.md#backup-destination).
+  - Più sicura: le password delle destinazioni sono isolate dalle applicazioni e accessibili solo con privilegi speciali.
+  - I conflitti di pianificazione vengono rilevati e ritentati automaticamente entro una finestra di un'ora.
+  - Nei cluster multi-nodo, i nodi possono instradare il traffico di backup attraverso altri nodi, rendendo raggiungibili le destinazioni on-premise anche dai nodi cloud.
+  - Ogni nodo verifica autonomamente la propria connettività e i propri permessi verso una destinazione, non solo il leader.
+  - Le destinazioni possono essere personalizzate con una configurazione Rclone personalizzata, abilitando opzioni avanzate (ad es. saltare la validazione dei certificati TLS) e nuovi tipi come SFTP e WebDAV; il tipo di destinazione Azure Blob Storage è stato rimosso a favore di questa funzionalità.
+  - Le applicazioni ripristinate tramite disaster recovery mantengono le pianificazioni di backup originali.
+
+- **Interruzione delle attività in corso con una conferma più sicura** \[Core 3.20.0\] -- Alcune attività di lunga durata, incluso il ripristino delle applicazioni, possono essere interrotte dall'interfaccia. Il passaggio di conferma è stato riprogettato per prevenire clic accidentali che potrebbero interrompere un'operazione importante, come un ripristino o una clonazione in corso.
+
+- **Spazio libero su disco mostrato durante la selezione del nodo** \[Core 3.20.0\] -- Durante l'installazione, la clonazione o il ripristino di un'applicazione, il passaggio di selezione del nodo mostra ora lo spazio libero del filesystem radice per ogni nodo, non solo per i nodi con un volume aggiuntivo.
+
+- **Shell limitata per gli utenti di servizio dei moduli** \[Core 3.20.0\] -- I moduli applicativi installati di recente assegnano ora `/sbin/nologin` come shell predefinita per il proprio utente di servizio, riducendo la superficie di attacco dei login interattivi mentre `runagent` continua a funzionare come prima. Le installazioni esistenti possono essere protette manualmente con questo comando[^nologin]:
+
+      runagent -l | xargs -l -t -r -- usermod -s /sbin/nologin
+
+[^nologin]: [Change shell to nologin | NS8 dev manual](https://nethserver.github.io/ns8-core/modules/rootless_rootfull/#unix-user)
+
+- **Password iniziale di root casuale sulle immagini precompilate** \[Core 3.20.0\] -- Le immagini precompilate di NS8 (.qcow2/.vmdk) non includono più la nota password di root predefinita. Una password casuale viene generata al primo avvio e mostrata sulla console/MOTD finché non viene modificata. Vedere [Installazione](../installation/install.md#install_image-section).
+
+- **Bootstrap più resiliente delle immagini precompilate** \[Core 3.20.0\] -- Le immagini precompilate ora completano la configurazione locale di Traefik (segreti e generazione dei certificati) al primo avvio anche se la rete è temporaneamente non disponibile, e l'azione `Crea cluster` gestisce in modo più robusto gli errori di validazione di rete/DNS.
+
+- **Registrazione delle email di notifica di sistema in uscita** \[Core 3.19.0\] -- Il comando `ns8-sendmail`, usato per inviare le notifiche di scadenza password e altre notifiche di sistema, registra ora un record strutturato (oggetto, mittente, primo destinatario, server remoto, stato SMTP) per ogni messaggio inviato.
+
+- **Supporto IPv6 nella lista di accesso consentito delle rotte HTTP** \[Core 3.18.4\] -- La restrizione `Consenti accesso da` sulle rotte HTTP accetta ora indirizzi e reti IPv6 oltre a IPv4.
+
+- **La password non scade mai per gli utenti OpenLDAP** \[OpenLDAP 2.7.0\] -- L'opzione "La password non scade mai", precedentemente disponibile solo per Active Directory, può ora essere abilitata anche per i singoli utenti OpenLDAP, sia dal cluster-admin che dal portale utente. Vedere [Utenti e gruppi](../installation/user_domains.md#user_groups-section).
+
+- **Supporto sperimentale per Spamhaus DQS in Rspamd** \[Mail 1.7.9\] -- L'applicazione Mail può ora utilizzare il Data Query Service (DQS) di Spamhaus, un'alternativa al protocollo DNSBL pubblico che richiede un token registrato e offre migliori prestazioni e minori restrizioni di fair-use. Vedere le [note del README di Mail](https://github.com/NethServer/ns8-mail#rspamd-plugin-for-spamhaus-dqs).
+
+- **Blocklist dei mittenti per Rspamd** \[Mail 1.7.10\] -- La configurazione Rspamd dell'applicazione Mail aggiunge nuove mappe per bloccare la posta in arrivo in base al TLD del mittente, al dominio esatto, al suffisso di dominio o all'indirizzo email completo, configurabili dall'[interfaccia web di Rspamd](../applications/mail.md#rspamd-web-interface).
+
+- **Aggiornamenti di WebTop** \[WebTop 1.5.6\] -- WebTop è stato aggiornato alla release upstream 5.32.0, aggiungendo l'opzione "Ricordami" nella pagina di login. Il campo della password one-time non utilizza più un input di tipo password, evitando indesiderati suggerimenti del browser per il salvataggio della password.
+
+- **Nextcloud 33** \[Nextcloud 1.7.0\] -- L'applicazione Nextcloud è stata aggiornata alla versione principale 33.
+
+- **Gestione dei volumi di Piler e configurazione personalizzata persistente** \[Piler 1.2.1, 1.2.2\] -- L'applicazione di archiviazione email Piler supporta ora la gestione dei volumi NS8, consentendo di posizionare il proprio storage su un disco aggiuntivo durante l'installazione, la clonazione o il ripristino. Un modello `config-site.php.local` può inoltre essere usato per mantenere le modifiche personalizzate a `config-site.php` tra un aggiornamento del modulo e l'altro e i salvataggi dall'interfaccia.
+
+- **Correzione del testo delle notifiche di CrowdSec** \[CrowdSec 1.1.4\] -- Le notifiche email relative alle decisioni di ban di CrowdSec usano ora la corretta forma singolare/plurale invece di utilizzare sempre la forma plurale.
+
+- **Dashboard Grafana per CrowdSec** \[CrowdSec 1.1.6\] -- È ora disponibile una dashboard Grafana con un exporter Prometheus per le metriche di CrowdSec tramite l'applicazione Metrics.
+
+- **Altri aggiornamenti applicativi** -- Dnsmasq 1.3.3, Mattermost 2.4.5, Loki 1.4.5, Matrix 0.0.5.
+
 ## Modifiche principali del 27-03-2026
 
 **Milestone 8.8**


### PR DESCRIPTION
## Summary
- Add a new "Major changes" section for NethServer 8.9 (NethServer/dev milestone 46), summarized from closed issues.
- Lead item is the new centralized backup architecture (the milestone's flagship goal), followed by other user-facing features, tagged with the NS8 component/version that ships each one.
- Includes a short "Other application updates" line for routine dependency bumps not already covered by a dedicated bullet.

Note: the `## Major changes on 2026-06-30` heading uses the milestone's GitHub due date as a placeholder — adjust to the actual publish date before merging.

## Test plan
- [x] `yarn build` (Docusaurus) to confirm the page renders without markdown errors
- [x] Review bullet wording and version tags against actual 8.9 releases before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)