### PR TITLE
docs: document CrowdSec 1.2.0 UI and NethVoice protection

### DIFF
--- a/docs/administrator-manual/applications/crowdsec.md
+++ b/docs/administrator-manual/applications/crowdsec.md
@@ -17,34 +17,104 @@ Once installed, CrowdSec is already fully functional and starts protecting NS8 a
 - **Mail**: Postfix (relay abuse, spam, invalid HELO/commands) and Dovecot (spam) brute-force/abuse detection.
 - **Database**: MariaDB and PostgreSQL brute-force login detection.
 - **FTP**: ProFTPD and vsftpd brute force and user enumeration.
+- **NethVoice**: HTTP brute force against the middleware API, reports API, and admin login, plus exploit-path scanning; SIP brute force against Kamailio. Enabled by default on a fresh install of NethVoice alongside CrowdSec; on an upgrade it stays off until you enable it from the `Collections` page (see below).
 - **Good-actor whitelist**: known legitimate crawlers/bots are automatically excluded from bans.
 
-## Configuration
+## Web interface
 
-From the web interface you can configure:
+The module's side menu gives access to the following pages: `Status`,
+`Detections`, `Collections`, `Blocklists`, `Settings`, and `About`.
 
-- mail notification by adding one address per line inside `Email notifications` field: notifications will work only if [Email notifications](../configuration/email_notifications.md) has been configured
-- IP and network which will never be blocked
-- dynamic and static ban time
+### Status
 
-As default, CrowdSec will send some telemetry to remote CrowdSec-owned servers. The servers use such data to compose a community blocklist which is sent back to your installation. If you do not want to share such data and disable the community blocklist, you can do it by disabling the `Enable central API` option under the `Advanced` section.
+Shows an overview of the application (restart action), the installation node,
+backup status, and a link to the logs.
 
-You can also connect your instance to [CrowdSec console](https://app.crowdsec.net) by filling the `Enroll key` optional field.
+### Detections
 
-CrowdSec sends a daily notification email listing newly blocked IPs to the configured recipients. If the default threshold of 100 new blocked IPs is reached before the daily report, the notification is sent immediately. The `Notification threshold` field, under the `Advanced` section, controls this value and can be set between 1 and 10000.
+Detections are suspicious activities found by CrowdSec, such as repeated login
+failures or known attack patterns. A detection does not always result in a
+blocked IP.
+
+The table lists `Detected at`, `Scenario`, `Source IP`, `Country`,
+`Action` (`Blocked`, `Block expired`, or `-` when no decision was taken), and
+`Events` count. Use the search box to filter by IP or scenario, and the
+`Events to show` selector to limit how many recent events are loaded. Each
+row has a `Details` link that opens the full event log for that detection.
+A `Delete all detections` button clears the whole list. This page exposes
+what was previously only visible with `cscli alerts list`.
+
+### Collections
+
+Collections add detection support for specific services, such as SSH, Nginx,
+or WordPress. Enable only the collections that match the services installed
+on this server; a link to the [CrowdSec Hub](https://app.crowdsec.net/hub)
+lets you check what each collection detects before enabling it.
+
+The table lists `Name`, `Status`, `Version`, and `Description`, with
+an `Enable`/`Disable` action per row. For example, the `nethesis/nethvoice`
+collection detects brute-force and exploit-scan attacks against the NethVoice
+application (SIP and HTTP); it ships disabled after an upgrade and must be
+enabled from this page.
+
+### Blocklists
+
+This page replaces the former `Banned IP` page and is organized in three tabs.
+
+#### Local blocklist
+
+IP addresses currently blocked by this server based on local CrowdSec
+decisions. The table lists `Blocked at`, `IP address`, `Time remaining`,
+and `Reason`, with a search box and per-row `Unblock`, plus an
+`Unblock all` action.
+
+#### Community blocklist
+
+IP addresses shared by the CrowdSec community and received through the
+Central API (CAPI). As default, CrowdSec will send some telemetry to remote
+CrowdSec-owned servers; the servers use such data to compose a community
+blocklist which is sent back to your installation. If you do not want to
+share such data, disable the `Central API and signal sharing` toggle — this
+also disables the `Community blocklist` toggle below it.
+
+You can connect your instance to the [CrowdSec console](https://app.crowdsec.net)
+by filling the `Enroll key` optional field. The `Central API status` tag
+shows whether the instance is connected. The number of IPs currently listed in
+the community blocklist is shown next to a search box that lets you check
+whether a given IP is included.
+
+Disabling the Central API or the community blocklist purges the CAPI-sourced
+decisions from this server automatically.
+
+CrowdSec provides a [community blocklist](https://docs.crowdsec.net/docs/next/central_api/community_blocklist) that is shared among all users; enabling `Central API and signal sharing` plus enrolling your instance in the console activates it. To access the full community blocklist (beyond the Lite version), you must share at least some ban decisions with the Central API every 24 hours. If your server has few or no bans, it will be considered as a blocking state, preventing access to the complete blocklist.
+
+#### Allowlist
+
+Trusted IP addresses, CIDR ranges, and domain names that should never be
+blocked. Enter one entry per line, for example:
+
+```
+192.168.1.10
+192.168.1.0/24
+trusted.example.com
+```
+
+### Settings
+
+- `Local network blocking`: disabled as default, private/LAN traffic is
+  never banned. Enable this toggle if you also want CrowdSec to block
+  offending IPs on your local networks.
+- `Block duration`: choose `Incremental` to increase the duration for
+  repeated detections from the same IP, or `Fixed` to always use the same
+  duration. Either way, enter the duration in minutes as free text.
+- mail notification by adding one address per line inside the `Email recipients for notifications` field: notifications will work only if [Email notifications](../configuration/email_notifications.md) has been configured — a link to the cluster email settings is shown when none is configured yet.
+- `Notification threshold`: CrowdSec sends a daily notification email listing newly blocked IPs to the configured recipients. If this threshold of new blocked IPs is reached before the daily report, the notification is sent immediately. Can be set between 1 and 10000 (100 as default).
 
 CrowdSec data is accessible from the `CrowdSec Overview` and `CrowdSec Metrics` Grafana dashboards, as explained in [Grafana access](../configuration/metrics.md#grafana_access-section).
 
-### Community blocklist vs Community blocklist (Lite)
-
-CrowdSec provides a [community blocklist](https://docs.crowdsec.net/docs/next/central_api/community_blocklist) that is shared among all users. To activate this feature, you need to:
-
-- Enable the Central API option.
-- Enroll your CrowdSec instance in the console.
-
-To access the full community blocklist (beyond the Lite version), you must share at least some ban decisions with the Central API every 24 hours. If your server has few or no bans, it will be considered as a blocking state, preventing access to the complete blocklist.
-
 ## Command-line interface
+
+Most of the actions above are also available from the command line.
 
 The `cscli` command is a powerful command-line interface to access advanced Crowdsec functions. To run `cscli`, you have to enter the application environment first. Type in a root shell the following command
 

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/applications/crowdsec.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/applications/crowdsec.md
@@ -17,34 +17,69 @@ Una volta installato, CrowdSec è già completamente funzionante e inizia a prot
 - **Mail**: rilevamento di abuso/tentativi di accesso forzato per Postfix (abuso di relay, spam, HELO/comandi non validi) e Dovecot (spam).
 - **Database**: rilevamento di tentativi di accesso forzato per MariaDB e PostgreSQL.
 - **FTP**: rilevamento di tentativi di accesso forzato e enumerazione utenti per ProFTPD e vsftpd.
+- **NethVoice**: forza bruta HTTP contro l'API middleware, l'API dei report e il login amministrativo, oltre alla scansione dei percorsi di exploit; forza bruta SIP contro Kamailio. Abilitato di default su una nuova installazione di NethVoice insieme a CrowdSec; in caso di aggiornamento, rimane disabilitato fino a quando non lo abiliti dalla pagina `Collections` (vedi sotto).
 - **Whitelist di attori legittimi**: crawler/bot legittimi noti sono automaticamente esclusi dai blocchi.
 
-## Configurazione {#configuration}
+## Interfaccia web
 
-Dall'interfaccia web puoi configurare:
+Il menu laterale del modulo offre accesso alle seguenti pagine: `Status`, `Detections`, `Collections`, `Blocklists`, `Settings` e `About`.
 
-- le notifiche email aggiungendo un indirizzo per riga nel campo `Email notifications`: le notifiche funzionano solo se [Email notifications](../configuration/email_notifications.md) è stato configurato
-- gli IP e le reti che non verranno mai bloccati
-- la durata dei ban dinamici e statici
+### Status
 
-Per impostazione predefinita, CrowdSec invia alcuni dati di telemetria a server remoti gestiti da CrowdSec. I server usano questi dati per comporre una community blocklist che viene poi inviata alla tua installazione. Se non vuoi condividere questi dati e vuoi disabilitare la community blocklist, puoi farlo disabilitando l'opzione `Enable central API` nella sezione `Advanced`.
+Mostra una panoramica dell'applicazione (azione di riavvio), il nodo di installazione, lo stato del backup e un link ai log.
 
-Puoi anche collegare la tua istanza alla [CrowdSec console](https://app.crowdsec.net) compilando il campo facoltativo `Enroll key`.
+### Rilevamenti
 
-CrowdSec invia ai destinatari configurati un'email di notifica giornaliera con l'elenco dei nuovi IP bloccati. Se la soglia predefinita di 100 nuovi IP bloccati viene raggiunta prima del report giornaliero, la notifica viene inviata immediatamente. Il campo `Notification threshold`, nella sezione `Advanced`, controlla questo valore e può essere impostato tra 1 e 10000.
+I rilevamenti sono attività sospette individuate da CrowdSec, come ripetuti fallimenti di login o schemi di attacco noti. Un rilevamento non comporta sempre il blocco di un IP.
 
-I dati di CrowdSec sono accessibili dalle dashboard Grafana `CrowdSec Overview` e `CrowdSec Metrics`, come spiegato in [accesso a Grafana](../configuration/metrics.md#grafana_access-section).
+La tabella elenca `Rilevato il`, `Scenario`, `IP sorgente`, `Paese`, `Azione` (`Blocked`, `Block expired` o `-` quando non è stata presa alcuna decisione) e il conteggio degli `Eventi`. Usa il campo di ricerca per filtrare per IP o scenario e il selettore `Eventi da mostrare` per limitare il numero di eventi recenti caricati. Ogni riga ha un link `Details` che apre il log completo degli eventi per quel rilevamento. Un pulsante `Delete all detections` cancella l'intero elenco. Questa pagina espone ciò che in precedenza era visibile solo con il comando `cscli alerts list`.
 
-### Community blocklist vs Community blocklist (Lite)
+### Collezioni
 
-CrowdSec fornisce una [community blocklist](https://docs.crowdsec.net/docs/next/central_api/community_blocklist) condivisa tra tutti gli utenti. Per attivare questa funzionalità, devi:
+Le collezioni aggiungono supporto per il rilevamento di servizi specifici, come SSH, Nginx o WordPress. Abilita solo le collezioni che corrispondono ai servizi installati su questo server; un link al [CrowdSec Hub](https://app.crowdsec.net/hub) consente di verificare cosa rileva ogni collezione prima di abilitarla.
 
-- abilitare l'opzione Central API
-- registrare la tua istanza CrowdSec nella console
+La tabella elenca `Nome`, `Stato`, `Versione` e `Descrizione`, con un'azione `Enable`/`Disable` per riga. Ad esempio, la collezione `nethesis/nethvoice` rileva attacchi di forza bruta e scansioni di exploit contro l'applicazione NethVoice (SIP e HTTP); viene fornita disabilitata dopo un aggiornamento e deve essere abilitata da questa pagina.
 
-Per accedere alla community blocklist completa, oltre alla versione Lite, devi condividere almeno alcune decisioni di ban con la Central API ogni 24 ore. Se il tuo server ha pochi o nessun ban, verrà considerato in stato di blocco, impedendo l'accesso alla blocklist completa.
+### Liste di blocco
+
+Questa pagina sostituisce la precedente pagina `Banned IP` ed è organizzata in tre schede.
+
+#### Lista di blocco locale
+
+Indirizzi IP attualmente bloccati da questo server in base alle decisioni locali di CrowdSec. La tabella elenca `Bloccato il`, `Indirizzo IP`, `Tempo rimanente` e `Motivo`, con un campo di ricerca e un'azione `Unblock` per riga, oltre a un'azione `Unblock all`.
+
+#### Lista di blocco della community
+
+Indirizzi IP condivisi dalla community di CrowdSec e ricevuti tramite l'API centrale (CAPI). Di default, CrowdSec invia alcune telemetrie ai server di proprietà di CrowdSec; i server utilizzano tali dati per comporre una lista di blocco della community che viene restituita alla tua installazione. Se non desideri condividere tali dati, disabilita l'interruttore `Central API and signal sharing` — ciò disabilita anche l'interruttore `Community blocklist` sottostante.
+
+Puoi connettere la tua istanza alla [console di CrowdSec](https://app.crowdsec.net) compilando il campo opzionale `Enroll key`. Il tag `Central API status` mostra se l'istanza è connessa. Il numero di IP attualmente elencati nella lista di blocco della community è mostrato accanto a un campo di ricerca che consente di verificare se un determinato IP è incluso.
+
+Disabilitare la Central API o la lista di blocco della community elimina automaticamente le decisioni provenienti dalla CAPI da questo server.
+
+CrowdSec fornisce una [lista di blocco della community](https://docs.crowdsec.net/docs/next/central_api/community_blocklist) condivisa tra tutti gli utenti; abilitare `Central API and signal sharing` e iscrivere la tua istanza nella console la attiva. Per accedere alla lista di blocco completa (oltre alla versione Lite), devi condividere almeno alcune decisioni di blocco con la Central API ogni 24 ore. Se il tuo server ha pochi o nessun blocco, sarà considerato in uno stato di blocco, impedendo l'accesso alla lista di blocco completa.
+
+#### Lista di permessi
+
+Indirizzi IP, intervalli CIDR e nomi di dominio attendibili che non devono mai essere bloccati. Inserisci un elemento per riga, ad esempio:
+
+```
+192.168.1.10
+192.168.1.0/24
+trusted.example.com
+```
+
+### Impostazioni
+
+- `Blocco della rete locale`: disabilitato di default, il traffico privato/LAN non viene mai bloccato. Abilita questo interruttore se desideri che CrowdSec blocchi anche gli IP offensivi sulle tue reti locali.
+- `Durata del blocco`: scegli `Incremental` per aumentare la durata per rilevamenti ripetuti dallo stesso IP, oppure `Fixed` per utilizzare sempre la stessa durata. In entrambi i casi, inserisci la durata in minuti come testo libero.
+- Notifica via email aggiungendo un indirizzo per riga nel campo `Email recipients for notifications`: le notifiche funzioneranno solo se [Email notifications](../configuration/email_notifications.md) è stato configurato — un link alle impostazioni email del cluster viene mostrato quando non è ancora configurato.
+- `Notification threshold`: CrowdSec invia un'email di notifica giornaliera elencando i nuovi IP bloccati ai destinatari configurati. Se questa soglia di nuovi IP bloccati viene raggiunta prima del report giornaliero, la notifica viene inviata immediatamente. Può essere impostata tra 1 e 10000 (100 di default).
+
+I dati di CrowdSec sono accessibili dalle dashboard `CrowdSec Overview` e `CrowdSec Metrics` di Grafana, come spiegato in [Accesso a Grafana](../configuration/metrics.md#grafana_access-section).
 
 ## Interfaccia a riga di comando
+
+La maggior parte delle azioni sopra descritte è disponibile anche dalla riga di comando.
 
 Il comando `cscli` è una potente interfaccia a riga di comando per accedere alle funzioni avanzate di CrowdSec. Per eseguire `cscli`, devi prima entrare nell'ambiente dell'applicazione. Digita il seguente comando in una shell di root
 


### PR DESCRIPTION
## Summary
Documents the ns8-crowdsec 1.2.0 web UI (Detections, Collections, Blocklists — replacing Banned IP — and reworked Settings) plus the new default NethVoice/Kamailio SIP brute-force protection.

## How to test
Run `yarn build` and check the CrowdSec chapter under Administrator manual > Applications.