### PR TITLE
docs: document default folder creation behavior for Mail

### DIFF
--- a/docs/administrator-manual/applications/mail.md
+++ b/docs/administrator-manual/applications/mail.md
@@ -439,6 +439,14 @@ The standard SMTP port 25 is reserved for mail transfers between MTA servers. Ma
 
 :::
 
+:::note
+
+When a mailbox is created, only the `Inbox`, `Trash`, and `Junk` folders exist. The `Drafts` and `Sent` folders are created automatically only at the first login into Roundcube or WebTop.
+
+If a third-party IMAP client is configured before the first Roundcube or WebTop login, it may create its own `Drafts`/`Sent` folders using localized names (e.g. `Brouillons`/`Éléments envoyés` in French). These are not recognized as equivalent to the standard folders, so a later webmail login can create duplicate `Drafts`/`Sent` folders alongside them. To avoid this, log into Roundcube or WebTop at least once before configuring any other IMAP client.
+
+:::
+
 Refer to the [Webtop application](webtop.md#email_autoconfig) for the implementation of automatic configuration protocols like Autodiscover and Autoconfig.
 
 ## Mail outbound connections {#mail-outbound-connections}

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/applications/mail.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/applications/mail.md
@@ -439,6 +439,16 @@ La porta SMTP standard 25 è riservata ai trasferimenti di posta tra server MTA.
 
 :::
 
+:::note
+
+Quando una casella di posta viene creata, esistono solo le cartelle `Inbox`, `Trash` e `Junk`. Le cartelle `Drafts` e `Sent` vengono create automaticamente solo al primo login da Roundcube o WebTop.
+
+Se un client IMAP di terze parti viene configurato prima del primo login da Roundcube o WebTop, potrebbe creare le proprie cartelle `Drafts`/`Sent` utilizzando nomi localizzati (es. `Bozze`/`Elementi inviati` in italiano). Queste non vengono riconosciute come equivalenti alle cartelle standard, quindi un successivo login da webmail può creare cartelle `Drafts`/`Sent` duplicate.
+
+Per evitare ciò, accedere a Roundcube o WebTop almeno una volta prima di configurare qualsiasi altro client IMAP.
+
+:::
+
 Fai riferimento all'applicazione [Webtop](webtop.md#email_autoconfig) per l'implementazione dei protocolli di configurazione automatica come Autodiscover e Autoconfig.
 
 ## Connessioni in uscita di Mail {#mail-outbound-connections}

--- a/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/applications/mail.md
+++ b/i18n/it/docusaurus-plugin-content-docs/current/administrator-manual/applications/mail.md
@@ -443,9 +443,7 @@ La porta SMTP standard 25 è riservata ai trasferimenti di posta tra server MTA.
 
 Quando una casella di posta viene creata, esistono solo le cartelle `Inbox`, `Trash` e `Junk`. Le cartelle `Drafts` e `Sent` vengono create automaticamente solo al primo login da Roundcube o WebTop.
 
-Se un client IMAP di terze parti viene configurato prima del primo login da Roundcube o WebTop, potrebbe creare le proprie cartelle `Drafts`/`Sent` utilizzando nomi localizzati (es. `Bozze`/`Elementi inviati` in italiano). Queste non vengono riconosciute come equivalenti alle cartelle standard, quindi un successivo login da webmail può creare cartelle `Drafts`/`Sent` duplicate.
-
-Per evitare ciò, accedere a Roundcube o WebTop almeno una volta prima di configurare qualsiasi altro client IMAP.
+Se un client IMAP di terze parti viene configurato prima del primo login da Roundcube o WebTop, potrebbe creare le proprie cartelle `Drafts`/`Sent` utilizzando nomi localizzati (es. `Bozze`/`Elementi inviati` in italiano). Queste non vengono riconosciute come equivalenti alle cartelle standard, quindi un successivo login da webmail può creare cartelle `Drafts`/`Sent` duplicate. Per evitare ciò, accedere a Roundcube o WebTop almeno una volta prima di configurare qualsiasi altro client IMAP.
 
 :::
 


### PR DESCRIPTION
Explain that Drafts and Sent folders are only created at first Roundcube/WebTop login, and that connecting a third-party IMAP client beforehand can create duplicate localized folders.

Refs NethServer/dev#8104